### PR TITLE
Fix waveform zooming

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -47,6 +47,7 @@ body {
   font-family: 'AdobeClean-Regular';
   user-select: none;
   margin-left: 0;
+  overflow: hidden;
 }
 
 a{
@@ -467,6 +468,7 @@ input[type=number]::-webkit-outer-spin-button {
   height: 20px;
   bottom:0;
   position: fixed;
+  z-index: 10;
 }
 
 #licenser-btn{

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -922,12 +922,12 @@ function playbackHandler(){
 }
 
 function zoomWaveform(e){
-    e.preventDefault();
+    if(e.ctrlKey){
+      e.preventDefault();
+    }
     let direction = Math.sign(-e.deltaY);
     let force = Math.log((Math.abs(e.deltaY)/12)+1)/30;
     let newWaveformZoom = Math.max(Math.min(waveformZoom + direction*force,1),0);
-    console.log('force ',force)
-    console.log('new ',newWaveformZoom)
     // For min zoom set overflow to visible so that handles show correctly
     if(newWaveformZoom == 0){
         document.querySelector("wave").style.overflow = "visible"

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -924,12 +924,12 @@ function playbackHandler(){
 function zoomWaveform(e){
     e.preventDefault();
     let direction = Math.sign(-e.deltaY);
-    let force = Math.log((Math.abs(e.deltaY)/12)+1)/10;
+    let force = Math.log((Math.abs(e.deltaY)/12)+1)/30;
     let newWaveformZoom = Math.max(Math.min(waveformZoom + direction*force,1),0);
     console.log('force ',force)
     console.log('new ',newWaveformZoom)
     // For min zoom set overflow to visible so that handles show correctly
-    if(waveformZoom == 0){
+    if(newWaveformZoom == 0){
         document.querySelector("wave").style.overflow = "visible"
     }
     if(waveformZoom === newWaveformZoom){
@@ -940,7 +940,7 @@ function zoomWaveform(e){
     var wave = document.querySelector("wave");
     var pointerPos = e.clientX - wave.getBoundingClientRect().x;
     var offset = (wave.scrollLeft + pointerPos)/wave.scrollWidth;
-    wavesurfer.zoom((100-minPixPerSec)*(waveformZoom**2)+minPixPerSec);
+    wavesurfer.zoom((100-minPixPerSec)*(waveformZoom**3)+minPixPerSec);
     var position = wave.scrollWidth*offset - pointerPos;
     wave.scrollTo(position,0);
 }


### PR DESCRIPTION
## In this PR

- Disable scrolling for the window of the extension
- Disable `ctrlKey` modifier and `deltaY` checks for performing zoom in the waveform preview
- Fix speed + arch of the zooming in the waveform preview


### Note to reviewer

If possible test with mouse + trackpad to verify zooming works as expected on both.