### PR TITLE
Issue 52: [ENG] Remove Opt-in info from Local Storage when user unchecks box

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1404,7 +1404,7 @@ function setPrivacy() {
 }
 
 function checkConsent(){
-    if (localStorage.getItem("privacy") === null) {
+    if (localStorage.getItem("privacy") === null || localStorage.getItem("privacy") === 'null') {
         if (consentRequired()){
             localStorage.setItem("privacy", "false");
         }
@@ -1727,7 +1727,7 @@ function acProductLineIntent(userEmail){
 
 // Register - Login - Reset Password
 function formActionTrack(type, userID, userEmail){
-    if (localStorage.privacy === "false")
+    if (localStorage.getItem("privacy") === "false")
         return;
     
     var action, formEvent, isloggedin;
@@ -1771,7 +1771,7 @@ function formActionTrack(type, userID, userEmail){
 
 // PageInfo
 function pageInfoTrack(){
-    if (localStorage.privacy === "false")
+    if (localStorage.getItem("privacy") === "false")
         return;
 
     var userid = (localStorage.getItem("userID") !== null && localStorage.getItem("userID") !== 'null')
@@ -1803,7 +1803,7 @@ function pageInfoTrack(){
 
 // User Notifications
 function userNotificationsTrack(responseCode){
-    if (localStorage.privacy === "false")
+    if (localStorage.getItem("privacy") === "false")
         return;
 
     var userid = (localStorage.getItem("userID") !== null && localStorage.getItem("userID") !== 'null')
@@ -1836,7 +1836,7 @@ function userNotificationsTrack(responseCode){
 
 // Audio Import
 function audioImportTrack(actionType, fileLength){
-    if (localStorage.privacy === "false")
+    if (localStorage.getItem("privacy") === "false")
         return;
 
     var userid = (localStorage.getItem("userID") !== null && localStorage.getItem("userID") !== 'null')
@@ -1869,7 +1869,7 @@ function audioImportTrack(actionType, fileLength){
 
 // Create Markers
 function createMarkersTrack(numberMarkers, fileLength){
-    if (localStorage.privacy === "false")
+    if (localStorage.getItem("privacy") === "false")
         return;
 
     var userid = (localStorage.getItem("userID") !== null && localStorage.getItem("userID") !== 'null')
@@ -1902,7 +1902,7 @@ function createMarkersTrack(numberMarkers, fileLength){
 
 // Music Cellar Link
 function musicCellarLinkTrack(){
-    if (localStorage.privacy === "false")
+    if (localStorage.getItem("privacy") === "false")
         return;
         
     var userid = (localStorage.getItem("userID") !== null && localStorage.getItem("userID") !== 'null')

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1394,8 +1394,11 @@ function accountIconShowHide(){
 
 function setPrivacy() {
   var checkBox = document.getElementById("privacy-policy-checkbox");
+  var checkBoxRegister = document.getElementById("privacy-policy-form-checkbox-register");
+  var checkBoxLogin = document.getElementById("privacy-policy-form-checkbox-login");
 
-  if (checkBox.checked == true){
+
+  if (checkBox.checked == true || checkBoxRegister.checked == true || checkBoxLogin.checked == true){
     localStorage.setItem("privacy", "true");
   }
   else {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -20,34 +20,11 @@
 // Check if user is already logged in
 document.addEventListener('DOMContentLoaded', function(e) {
     if (typeof(Storage) !== "undefined") {
-        if (localStorage.getItem("privacy") === null) {
-            if (consentRequired()){
-                localStorage.setItem("privacy", "false");
-            }
-            else{
-                localStorage.setItem("privacy", "true");
-            }
-        }
+        checkConsent();
 
         if (localStorage.getItem("colorMode") === null) {
             localStorage.setItem("colorMode", "Default");
         }
-    }
-
-    // Initial value of privacy checkbox
-    var checkBox = document.getElementById("privacy-policy-checkbox");
-    var checkBoxRegister = document.getElementById("privacy-policy-form-checkbox-register");
-    var checkBoxLogin = document.getElementById("privacy-policy-form-checkbox-login");
-
-    if (localStorage.getItem("privacy") === "true"){
-        checkBox.checked = true;
-        checkBoxRegister.checked = true;
-        checkBoxLogin.checked = true;
-    }
-    else {
-        checkBox.checked = false;
-        checkBoxRegister.checked = false;
-        checkBoxLogin.checked = false;
     }
 
     themeInit();
@@ -448,9 +425,6 @@ function selectFileFromDropdownHandler()
  */
 function systemImportHandler(ev) 
 {
-    const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-    const reader = new FileReader();
-
     // If the file came from the Drag and Drop event
     if (ev.type == "drop"){
 
@@ -496,31 +470,12 @@ function systemImportHandler(ev)
         }
         // Imported through system
         var file = ev.dataTransfer.files[0];
-        var type = 'Filesystem (Drag & Drop)';
-
-        reader.onload = function(e){
-            const arrayBuffer = e.target.result;
-            audioContext.decodeAudioData(arrayBuffer)
-                .then(function(buffer){
-                const duration = new Date(buffer.duration * 1000).toISOString().substr(14, 5);
-                audioImportTrack('Drag & Drop', duration);
-            });
-        };
-        reader.readAsArrayBuffer(file);
+        var type = 'Drag & Drop';
     }
     else{
         // Regular system import
         var file = document.getElementById("file-input").files[0];
-        var type = 'Filesystem (Button)';
-        reader.onload = function(e){
-            const arrayBuffer = e.target.result;
-            audioContext.decodeAudioData(arrayBuffer)
-                .then(function(buffer){
-                const duration = new Date(buffer.duration * 1000).toISOString().substr(14, 5);
-                audioImportTrack('Select File', duration);
-            });
-        };
-        reader.readAsArrayBuffer(file);
+        var type = 'Select File';
     }
 
     // Set the import mode to filesystem
@@ -540,7 +495,22 @@ function importFile(file, type)
     if(!newFile || !storeOutputIfExists(file)){      
         raiseAlert("Error!", "Error while processing Input file!");
         return;
-    }  
+    } 
+
+    // Send event to dataLayer
+    const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    const reader = new FileReader();
+
+    reader.onload = function(e){
+        const arrayBuffer = e.target.result;
+        audioContext.decodeAudioData(arrayBuffer)
+            .then(function(buffer){
+            const duration = new Date(buffer.duration * 1000).toISOString().substr(14, 5);
+            audioImportTrack(type, duration);
+        });
+    };
+    reader.readAsArrayBuffer(file);
+
 
     if(type == "Project"){
         // Show the imported file on Dropdown button
@@ -1204,6 +1174,7 @@ function changeForm(page){
         toggleMainRegLogModal();
     }
 
+    checkConsent();
     if (page == 'Login'){
         if (modalRegister.classList.contains('show')){
             modalRegister.classList.remove('show');
@@ -1430,6 +1401,33 @@ function setPrivacy() {
   else {
     localStorage.setItem("privacy", "false");
   }
+}
+
+function checkConsent(){
+    if (localStorage.getItem("privacy") === null) {
+        if (consentRequired()){
+            localStorage.setItem("privacy", "false");
+        }
+        else{
+            localStorage.setItem("privacy", "true");
+        }
+    }
+
+    // Initial value of privacy checkbox
+    var checkBox = document.getElementById("privacy-policy-checkbox");
+    var checkBoxRegister = document.getElementById("privacy-policy-form-checkbox-register");
+    var checkBoxLogin = document.getElementById("privacy-policy-form-checkbox-login");
+
+    if (localStorage.getItem("privacy") === "true"){
+        checkBox.checked = true;
+        checkBoxRegister.checked = true;
+        checkBoxLogin.checked = true;
+    }
+    else {
+        checkBox.checked = false;
+        checkBoxRegister.checked = false;
+        checkBoxLogin.checked = false;
+    }
 }
 
 function setColorMode() {
@@ -1695,6 +1693,9 @@ function updateUserInfo(userID, userEmail){
             }
             if (localStorage.getItem("userEmail") !== null && localStorage.getItem("userEmail") !== 'null') {
                 localStorage.setItem("userEmail", null);
+            }
+            if (localStorage.getItem("privacy") !== null && localStorage.getItem("privacy") !== 'null') {
+                localStorage.setItem("privacy", null);
             }
         }
     }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1142,7 +1142,7 @@ function closeLoadingModal(){
 function toggleSideMenu(){
     var modalMainRegLog = document.getElementById('register-login')
     var modal = document.getElementById('side-menu');
-
+    checkConsent();
     if (!modalMainRegLog.classList.contains('show') && !modal.classList.contains('show')){
         modal.classList.add('show');
     }
@@ -1174,8 +1174,8 @@ function changeForm(page){
         toggleMainRegLogModal();
     }
 
-    checkConsent();
     if (page == 'Login'){
+        checkConsent();
         if (modalRegister.classList.contains('show')){
             modalRegister.classList.remove('show');
         }
@@ -1202,6 +1202,7 @@ function changeForm(page){
     }
 
     if (page == 'Register'){
+        checkConsent();
         if (modalLogin.classList.contains('show')){
             modalLogin.classList.remove('show');
         }
@@ -1398,7 +1399,7 @@ function setPrivacy() {
   var checkBoxLogin = document.getElementById("privacy-policy-form-checkbox-login");
 
 
-  if (checkBox.checked == true || checkBoxRegister.checked == true || checkBoxLogin.checked == true){
+  if ((checkBox.checked == true || checkBoxRegister.checked == true || checkBoxLogin.checked == true) && localStorage.getItem("privacy") === "false"){
     localStorage.setItem("privacy", "true");
   }
   else {
@@ -1407,29 +1408,30 @@ function setPrivacy() {
 }
 
 function checkConsent(){
-    if (localStorage.getItem("privacy") === null || localStorage.getItem("privacy") === 'null') {
-        if (consentRequired()){
-            localStorage.setItem("privacy", "false");
-        }
-        else{
-            localStorage.setItem("privacy", "true");
-        }
-    }
-
     // Initial value of privacy checkbox
     var checkBox = document.getElementById("privacy-policy-checkbox");
     var checkBoxRegister = document.getElementById("privacy-policy-form-checkbox-register");
     var checkBoxLogin = document.getElementById("privacy-policy-form-checkbox-login");
 
-    if (localStorage.getItem("privacy") === "true"){
-        checkBox.checked = true;
-        checkBoxRegister.checked = true;
-        checkBoxLogin.checked = true;
+    if (localStorage.getItem("privacy") === null || localStorage.getItem("privacy") === 'null') {
+        if (consentRequired()){
+            localStorage.setItem("privacy", "false");
+            checkBox.checked = false;
+            checkBoxRegister.checked = false;
+            checkBoxLogin.checked = false;    
+        }
+        else{
+            localStorage.setItem("privacy", "true");
+            checkBox.checked = true;
+            checkBoxRegister.checked = true;
+            checkBoxLogin.checked = true;
+        }
     }
     else {
-        checkBox.checked = false;
-        checkBoxRegister.checked = false;
-        checkBoxLogin.checked = false;
+        var privacyVal = (localStorage.getItem("privacy") === "true");
+        checkBox.checked = privacyVal;
+        checkBoxRegister.checked = privacyVal;
+        checkBoxLogin.checked = privacyVal;
     }
 }
 


### PR DESCRIPTION
On the final QA of the BeatMarker epic from the growth team, we discovered two minor issues that needed fix:
1. The opt-in/opt-out checkbox wasn't working 100% properly when the user logs out and then decides to change the state of the checkbox. This happens because the opt-in data was staying in local storage and wasn't updated after the original push.
2. The 'Audio Import" event was firing even when BeatMarker failed to import the audio file.